### PR TITLE
tests(psmodule): add InvokeScriptStrict helper + document the binding-test pattern

### DIFF
--- a/VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs
+++ b/VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs
@@ -47,7 +47,7 @@ namespace VTest.PowerShell
                 new VisioAutomation.Core.Point(2.0, 2.0)
             });
 
-            CmdletBindingTests.Session.InvokeScript<object>(
+            CmdletBindingTests.Session.InvokeScriptStrict<object>(
                 "Lock-VisioShape -MoveX -Shape $s",
                 ("s", new[] { (IVisio.Shape)shape }));
 
@@ -70,13 +70,13 @@ namespace VTest.PowerShell
             });
 
             // First lock, then unlock, to verify the unlock path actually flips back.
-            CmdletBindingTests.Session.InvokeScript<object>(
+            CmdletBindingTests.Session.InvokeScriptStrict<object>(
                 "Lock-VisioShape -MoveX -Shape $s",
                 ("s", new[] { (IVisio.Shape)shape }));
             string after_lock = ((IVisio.Shape)shape).CellsU["LockMoveX"].FormulaU;
             MUT.Assert.AreEqual("1", after_lock, "Pre-condition: lock should set LockMoveX = 1");
 
-            CmdletBindingTests.Session.InvokeScript<object>(
+            CmdletBindingTests.Session.InvokeScriptStrict<object>(
                 "Unlock-VisioShape -MoveX -Shape $s",
                 ("s", new[] { (IVisio.Shape)shape }));
 
@@ -111,10 +111,8 @@ namespace VTest.PowerShell
                 bool threw = false;
                 try
                 {
-                    // $ErrorActionPreference = 'Stop' forces the cmdlet's thrown exception
-                    // to propagate as a runtime error rather than landing on the error stream.
-                    CmdletBindingTests.Session.InvokeScript<object>(
-                        "$ErrorActionPreference = 'Stop'; Export-VisioShape -Filename $f -Shape $s",
+                    CmdletBindingTests.Session.InvokeScriptStrict<object>(
+                        "Export-VisioShape -Filename $f -Shape $s",
                         ("f", export_path),
                         ("s", new[] { (IVisio.Shape)shape }));
                 }
@@ -167,10 +165,8 @@ namespace VTest.PowerShell
                 bool threw = false;
                 try
                 {
-                    // $ErrorActionPreference = 'Stop' makes cmdlet-thrown exceptions propagate
-                    // as runtime errors rather than landing silently on the error stream.
-                    CmdletBindingTests.Session.InvokeScript<object>(
-                        "$ErrorActionPreference = 'Stop'; New-VisioShape -Polyline -Points $p",
+                    CmdletBindingTests.Session.InvokeScriptStrict<object>(
+                        "New-VisioShape -Polyline -Points $p",
                         ("p", new[] { new VisioAutomation.Core.Point(1.0, 1.0) }));
                 }
                 catch (System.Exception)
@@ -197,10 +193,8 @@ namespace VTest.PowerShell
                 bool threw = false;
                 try
                 {
-                    // $ErrorActionPreference = 'Stop' makes cmdlet-thrown exceptions propagate
-                    // as runtime errors rather than landing silently on the error stream.
-                    CmdletBindingTests.Session.InvokeScript<object>(
-                        "$ErrorActionPreference = 'Stop'; New-VisioShape -Bezier -Points $p",
+                    CmdletBindingTests.Session.InvokeScriptStrict<object>(
+                        "New-VisioShape -Bezier -Points $p",
                         ("p", new[]
                         {
                             new VisioAutomation.Core.Point(0.0, 0.0),

--- a/VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs
+++ b/VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs
@@ -1,0 +1,222 @@
+using MUT = Microsoft.VisualStudio.TestTools.UnitTesting;
+using VisioPowerShell.Commands.VisioApplication;
+using VTest.PowerShell.Framework;
+using IVisio = Microsoft.Office.Interop.Visio;
+
+namespace VTest.PowerShell
+{
+    // Cmdlet parameter-binding regression tests: exercises PowerShell's binder
+    // via the runspace path (InvokeScript) rather than direct cmdlet.Invoke,
+    // because direct Invoke bypasses the binder.
+    //
+    // First slice of #173, focused on the regression class that shipped 4.6.1's
+    // four bugs (Lock/Unlock-VisioShape switches that didn't bind, Export-VisioShape
+    // inverted file-existence check, New-VisioShape polyline / Bezier minimum-point
+    // validation that didn't actually throw).
+
+    [MUT.TestClass]
+    public class CmdletBindingTests
+    {
+        private static readonly VisioPSSession Session = new VisioPSSession();
+
+        [MUT.ClassInitialize]
+        public static void ClassInitialize(MUT.TestContext context)
+        {
+            var new_visio_application = new NewVisioApplication();
+        }
+
+        [MUT.ClassCleanup]
+        public static void ClassCleanup()
+        {
+            try { CmdletBindingTests.Session.Cmd_Close_VisioApplication(true); }
+            catch (System.Exception) { }
+            CmdletBindingTests.Session.CleanUp();
+        }
+
+        // -- Lock-VisioShape / Unlock-VisioShape: switch parameters ---------------
+
+        [MUT.TestMethod]
+        public void LockVisioShape_MoveXSwitch_BindsAndSetsLockMoveXFormula()
+        {
+            // Regression: the -MoveX switch (and its peers) used to fail to bind,
+            // so Lock-VisioShape -MoveX silently left LockMoveX = "0".
+            var doc = CmdletBindingTests.Session.Cmd_New_VisioDocument();
+            var shape = CmdletBindingTests.Session.Cmd_New_VisioShape_rectangle(new[]
+            {
+                new VisioAutomation.Core.Point(0.0, 0.0),
+                new VisioAutomation.Core.Point(2.0, 2.0)
+            });
+
+            CmdletBindingTests.Session.InvokeScript<object>(
+                "Lock-VisioShape -MoveX -Shape $s",
+                ("s", new[] { (IVisio.Shape)shape }));
+
+            string movex = ((IVisio.Shape)shape).CellsU["LockMoveX"].FormulaU;
+            MUT.Assert.AreEqual("1", movex, "Lock-VisioShape -MoveX should set LockMoveX formula to '1'");
+
+            CmdletBindingTests.Session.Cmd_Close_VisioDocument(VTestPsArray.From(doc), true);
+        }
+
+        [MUT.TestMethod]
+        public void UnlockVisioShape_MoveXSwitch_BindsAndSetsLockMoveXFormulaToZero()
+        {
+            // Regression: the symmetric -MoveX switch on Unlock-VisioShape used to
+            // fail to bind, so a previously-locked shape stayed locked.
+            var doc = CmdletBindingTests.Session.Cmd_New_VisioDocument();
+            var shape = CmdletBindingTests.Session.Cmd_New_VisioShape_rectangle(new[]
+            {
+                new VisioAutomation.Core.Point(0.0, 0.0),
+                new VisioAutomation.Core.Point(2.0, 2.0)
+            });
+
+            // First lock, then unlock, to verify the unlock path actually flips back.
+            CmdletBindingTests.Session.InvokeScript<object>(
+                "Lock-VisioShape -MoveX -Shape $s",
+                ("s", new[] { (IVisio.Shape)shape }));
+            string after_lock = ((IVisio.Shape)shape).CellsU["LockMoveX"].FormulaU;
+            MUT.Assert.AreEqual("1", after_lock, "Pre-condition: lock should set LockMoveX = 1");
+
+            CmdletBindingTests.Session.InvokeScript<object>(
+                "Unlock-VisioShape -MoveX -Shape $s",
+                ("s", new[] { (IVisio.Shape)shape }));
+
+            string after_unlock = ((IVisio.Shape)shape).CellsU["LockMoveX"].FormulaU;
+            MUT.Assert.AreEqual("0", after_unlock, "Unlock-VisioShape -MoveX should set LockMoveX formula to '0'");
+
+            CmdletBindingTests.Session.Cmd_Close_VisioDocument(VTestPsArray.From(doc), true);
+        }
+
+        // -- Export-VisioShape: file-existence check + -Overwrite -----------------
+
+        [MUT.TestMethod]
+        public void ExportVisioShape_TargetExists_NoOverwrite_Throws()
+        {
+            // Regression: the file-existence check used to be inverted, so
+            // Export-VisioShape would happily clobber an existing file even
+            // without -Overwrite (or refuse to write to a nonexistent path).
+            var doc = CmdletBindingTests.Session.Cmd_New_VisioDocument();
+            var shape = CmdletBindingTests.Session.Cmd_New_VisioShape_rectangle(new[]
+            {
+                new VisioAutomation.Core.Point(0.0, 0.0),
+                new VisioAutomation.Core.Point(2.0, 2.0)
+            });
+
+            string export_path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "vtest_export_" + System.Guid.NewGuid().ToString("N") + ".png");
+            System.IO.File.WriteAllText(export_path, "pre-existing stub content");
+
+            try
+            {
+                bool threw = false;
+                try
+                {
+                    // $ErrorActionPreference = 'Stop' forces the cmdlet's thrown exception
+                    // to propagate as a runtime error rather than landing on the error stream.
+                    CmdletBindingTests.Session.InvokeScript<object>(
+                        "$ErrorActionPreference = 'Stop'; Export-VisioShape -Filename $f -Shape $s",
+                        ("f", export_path),
+                        ("s", new[] { (IVisio.Shape)shape }));
+                }
+                catch (System.Exception)
+                {
+                    threw = true;
+                }
+                MUT.Assert.IsTrue(threw, "Export-VisioShape should throw when target exists and -Overwrite is not set");
+
+                // The pre-existing stub content must still be there (the cmdlet must not have clobbered it).
+                MUT.Assert.AreEqual(
+                    "pre-existing stub content",
+                    System.IO.File.ReadAllText(export_path),
+                    "Export-VisioShape must not overwrite the file when -Overwrite is not set");
+            }
+            finally
+            {
+                if (System.IO.File.Exists(export_path))
+                {
+                    System.IO.File.Delete(export_path);
+                }
+            }
+
+            CmdletBindingTests.Session.Cmd_Close_VisioDocument(VTestPsArray.From(doc), true);
+        }
+
+        [MUT.TestMethod]
+        [MUT.Ignore("Blocked by #164: cmdlets that call TargetShapes.ResolveToSelection through the runspace path hit "
+            + "'CommandTarget: application does not match doc.application' because the runspace's Client and the test-host's "
+            + "Client disagree on which app/doc is active. The no-Overwrite path above doesn't bite because the cmdlet "
+            + "throws at the file-existence check before reaching ResolveToSelection. Re-enable when #164 lands.")]
+        public void ExportVisioShape_TargetExists_WithOverwrite_ReplacesFile()
+        {
+            // Intentionally empty body. Re-implement when #164 is resolved.
+        }
+
+        // -- New-VisioShape: polyline / Bezier minimum-point validation -----------
+
+        [MUT.TestMethod]
+        public void NewVisioShape_Polyline_FewerThan2Points_Throws()
+        {
+            // Regression: New-VisioShape -Polyline with 1 point used to silently
+            // fall through (Visio refused to draw with insufficient vertices, but
+            // the cmdlet's _check_num_Points() validation was a no-op on the
+            // throw path before 4.6.1).
+            var doc = CmdletBindingTests.Session.Cmd_New_VisioDocument();
+
+            try
+            {
+                bool threw = false;
+                try
+                {
+                    // $ErrorActionPreference = 'Stop' makes cmdlet-thrown exceptions propagate
+                    // as runtime errors rather than landing silently on the error stream.
+                    CmdletBindingTests.Session.InvokeScript<object>(
+                        "$ErrorActionPreference = 'Stop'; New-VisioShape -Polyline -Points $p",
+                        ("p", new[] { new VisioAutomation.Core.Point(1.0, 1.0) }));
+                }
+                catch (System.Exception)
+                {
+                    threw = true;
+                }
+                MUT.Assert.IsTrue(threw, "New-VisioShape -Polyline should throw when given fewer than 2 points");
+            }
+            finally
+            {
+                CmdletBindingTests.Session.Cmd_Close_VisioDocument(VTestPsArray.From(doc), true);
+            }
+        }
+
+        [MUT.TestMethod]
+        public void NewVisioShape_Bezier_FewerThan4Points_Throws()
+        {
+            // Regression: same shape as the polyline test, but Bezier requires
+            // at least 4 points (two endpoints + two control points).
+            var doc = CmdletBindingTests.Session.Cmd_New_VisioDocument();
+
+            try
+            {
+                bool threw = false;
+                try
+                {
+                    // $ErrorActionPreference = 'Stop' makes cmdlet-thrown exceptions propagate
+                    // as runtime errors rather than landing silently on the error stream.
+                    CmdletBindingTests.Session.InvokeScript<object>(
+                        "$ErrorActionPreference = 'Stop'; New-VisioShape -Bezier -Points $p",
+                        ("p", new[]
+                        {
+                            new VisioAutomation.Core.Point(0.0, 0.0),
+                            new VisioAutomation.Core.Point(1.0, 1.0)
+                        }));
+                }
+                catch (System.Exception)
+                {
+                    threw = true;
+                }
+                MUT.Assert.IsTrue(threw, "New-VisioShape -Bezier should throw when given fewer than 4 points");
+            }
+            finally
+            {
+                CmdletBindingTests.Session.Cmd_Close_VisioDocument(VTestPsArray.From(doc), true);
+            }
+        }
+    }
+}

--- a/VisioAutomation_2010/VTest.PowerShell/VisioPSSession.cs
+++ b/VisioAutomation_2010/VTest.PowerShell/VisioPSSession.cs
@@ -202,6 +202,18 @@ namespace VTest.PowerShell
             return results.ToList();
         }
 
+        // InvokeScript<T> with $ErrorActionPreference = 'Stop' prepended.
+        // PowerShell catches cmdlet-thrown exceptions and writes them to the error stream
+        // by default; without 'Stop', a thrown exception doesn't propagate, so a try/catch
+        // around InvokeScript never sees it. Use InvokeScriptStrict for tests that
+        // (a) expect the cmdlet to throw, so the test can catch the propagated exception, or
+        // (b) want any unexpected error from the cmdlet to surface as a test failure rather
+        //     than be silently dropped on the error stream.
+        public List<T> InvokeScriptStrict<T>(string script, params (string name, object value)[] variables)
+        {
+            return this.InvokeScript<T>("$ErrorActionPreference = 'Stop'; " + script, variables);
+        }
+
         public VisioPowerShell.Models.ShapeCells Cmd_New_VisioShapeCells()
         {
             var cmd = new VisioPowerShell.Commands.VisioShapeCells.NewVisioShapeCells();

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,6 +68,22 @@ Test fixtures (`VTest/datafiles/*`) are tagged `<Content Include="..." CopyToOut
 
 **Don't add `[DeploymentItem]` attributes.** Phase 1 commit `5cbf11cd` removed them — they were redundant given the `CopyToOutputDirectory` flag, and their only effect was triggering VS Test Explorer's deployment-mode behavior, which in turn dropped runtime dependencies on the floor.
 
+### `VTest.PowerShell`: cmdlet-binding tests via `InvokeScript` / `InvokeScriptStrict`
+
+`VTest.PowerShell` doesn't share the `Framework.VTest` base class; it tests cmdlets via a real PowerShell runspace hosted by [`VisioPSSession`](../VisioAutomation_2010/VTest.PowerShell/VisioPSSession.cs). Two paths are available:
+
+- **`Cmd_*` helpers** (e.g. `Cmd_New_VisioDocument`) — instantiate a cmdlet object in C# and call `cmd.Invoke()` directly. Bypasses PowerShell's parameter binder. Convenient for setup, but **wrong for tests of binding behavior**.
+- **`InvokeScript<T>` / `InvokeScriptStrict<T>`** — execute a PowerShell script through the runspace, exercising the real binder. Required for any test of positional binding, switch parameters, parameter sets, or pipeline binding.
+
+#### When to use which `InvokeScript` variant
+
+`InvokeScriptStrict<T>` is `InvokeScript<T>` with `$ErrorActionPreference = 'Stop'` prepended. PowerShell catches cmdlet-thrown exceptions and writes them to the error stream by default; without `'Stop'`, a thrown exception **does not propagate** to the caller, so a `try`/`catch` around `InvokeScript<T>` never sees it.
+
+- Use **`InvokeScriptStrict<T>`** for tests that expect the cmdlet to throw (so the test can catch the propagated exception), or that want any unexpected error from the cmdlet to surface as a test failure rather than be silently dropped on the error stream. **This is the right default for cmdlet-binding tests** ([`CmdletBindingTests.cs`](../VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs) is the canonical example).
+- Use plain **`InvokeScript<T>`** when the cmdlet is allowed to write non-fatal records to the error stream and the test only cares about the success-path return value.
+
+The longer-term cleanup (migrating cmdlets from raw `throw` to `ThrowTerminatingError(ErrorRecord)`, which always propagates regardless of `$ErrorActionPreference`) is tracked in [#191](https://github.com/saveenr/VisioAutomation/issues/191). Until that lands, `InvokeScriptStrict<T>` is the correct workaround for binding-test exception assertions.
+
 ## Quality gates
 
 ### MSTEST0030 enforced as error


### PR DESCRIPTION
## Summary

Tier 1 + Tier 2 of the cleanup that came out of [#173](https://github.com/saveenr/VisioAutomation/issues/173)'s first slice. The deeper Tier 3 fix (migrating cmdlets from raw \`throw\` to \`ThrowTerminatingError\`) is filed separately as [#191](https://github.com/saveenr/VisioAutomation/issues/191) for CY26Q3.

**Tier 2** — new helper [`VisioPSSession.InvokeScriptStrict<T>`](https://github.com/saveenr/VisioAutomation/blob/claude/invokescript-strict-helper/VisioAutomation_2010/VTest.PowerShell/VisioPSSession.cs) that prepends `$ErrorActionPreference = 'Stop'` to the script. Without that, PowerShell catches cmdlet-thrown exceptions and writes them to the error stream by default, which means a `try`/`catch` around `InvokeScript` never sees the propagated exception. Five existing tests in [`CmdletBindingTests.cs`](https://github.com/saveenr/VisioAutomation/blob/claude/invokescript-strict-helper/VisioAutomation_2010/VTest.PowerShell/CmdletBindingTests.cs) migrated to use it (the manual `\"$ErrorActionPreference = 'Stop'; \"` prefix is now centralized in the helper).

**Tier 1** — new subsection in [`docs/TESTING.md`](https://github.com/saveenr/VisioAutomation/blob/claude/invokescript-strict-helper/docs/TESTING.md) titled *VTest.PowerShell: cmdlet-binding tests via InvokeScript / InvokeScriptStrict*. Documents the two paths (`Cmd_*` vs `InvokeScript`), the `$ErrorActionPreference` quirk and when to use `InvokeScriptStrict`, and points at [#191](https://github.com/saveenr/VisioAutomation/issues/191) for the longer-term proper fix.

## Notes for the next reviewer / contributor

- Once [#191](https://github.com/saveenr/VisioAutomation/issues/191) lands, the `InvokeScriptStrict` workaround becomes redundant. The TESTING.md paragraph already says so. Tests can switch back to plain `InvokeScript` at that point.
- The `[Ignore]`'d `ExportVisioShape_TargetExists_WithOverwrite_ReplacesFile` is unaffected; it's blocked by [#190](https://github.com/saveenr/VisioAutomation/issues/190) / [#164](https://github.com/saveenr/VisioAutomation/issues/164) (the runspace-vs-direct-Client mismatch), not by the throw-propagation issue this PR addresses.

## Test plan

- [x] Build clean.
- [x] All 26 VTest.PowerShell tests produce the same outcomes (25 passed + 1 skipped); the helper migration didn't change behavior.
- [ ] Reviewer: skim the new helper in `VisioPSSession.cs` and the TESTING.md paragraph.

This PR is on top of [#189](https://github.com/saveenr/VisioAutomation/pull/189) (which adds `CmdletBindingTests.cs` itself). Easiest review order: merge [#189](https://github.com/saveenr/VisioAutomation/pull/189) first, then this PR's diff against master shrinks to just the 3-file delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)